### PR TITLE
specifying ruby version in the gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+ruby '1.9.3'
 
 gem 'rails', '3.2.13'
 


### PR DESCRIPTION
this is described on the bundler website here:
http://gembundler.com/v1.3/gemfile_ruby.html

services like Heroku use this directive to know what version of ruby to compile your assets in.
